### PR TITLE
Unity-compatible Release Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_install:
   - sudo apt-get install nunit-console
 
 script:
-  - xbuild /p:Configuration=Debug Bantam.sln
-  - nunit-console BantamTest/bin/Debug/BantamTest.dll
+  - xbuild /p:Configuration=Release Bantam.sln
+  - nunit-console BantamTest/bin/Release/BantamTest.dll
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ deploy:
     secure: y6v0TUgoO9hhwfsTnEFxi8k4MAa6RyG3jQaR9f8a3DmLyGaoAIK7bFQqgVRTK/XeNIIJsS7P4FBMmSrm+cxEbB27rKF9te0ep1YRCwEN5DNnV7+7pL/y6g9K7hwaLUE7q4ztmZzg+qaIPgtk/AQOxeK9KeHjFCvZ324C95OMaeao5afioOtOUfFjC1WxRewcRya/NyEyntoPmqZCKfcxCGJGs3MjCy2watHEJZCb2svzDk1KGRRYzkHJkzxkuKYkIkHh8n8DSNd2v+rchwb52Q5hlQJrtbtbgrvoZhI9Maz2g57CBnTQmJ1QgERrvp3L/ARPKOzPo+DEppQzPYzH2IEmLjst4AYZxcQYIzvx3GZfkC3zvsb8zIMH+zqWm74vcIhRZ8iT09oyuQCTE5IE5uDveusNNlQGlgre9jRzZqqen9inAkRPWowmAdNC183Lkor6Yiw1yZcYGfIDp0Sza9F9KuU2nGMGV0a8DHLbDVsaE+aPYwbIqc7KzzcuFuF+ElxQUUc4xTHXmV6Y45I7tg5Z/KLNVRukz09mdwyCUuFr46TlmSVo4zElMVPw+i81W10QwfT0nncTndMmvGXfIdRI93KhE8RP8sxou4jwMAGAFsLmgbbMjrb+RPuGV+/bfD3SryU/FDkGuZK3pFNWQ+CNFEIuImRzsuWxVvfksgA=
   skip_cleanup: true
   file:
-    - Bantam/bin/Debug/Bantam.dll
+    - Bantam/bin/Release/Bantam.dll
     - LICENSE
     - README.md
   on:

--- a/Bantam/Bantam.csproj
+++ b/Bantam/Bantam.csproj
@@ -7,6 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Bantam</RootNamespace>
     <AssemblyName>Bantam</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Previously, only the debug DLLs were compatible with Unity. The release DLLs are now also compatible with Unity by changing the project settings to target .NET 2.0.
