### PR TITLE
Recursive event handler removal

### DIFF
--- a/BantamTest/EventBusTest.cs
+++ b/BantamTest/EventBusTest.cs
@@ -139,6 +139,23 @@ namespace Bantam.Test
 
 			Assert.IsTrue(wasSecondListenerCalled, "Second listener was not executed.");
 		}
+
+		[Test]
+		public void RemoveListenerSucceedsWhenCalledFromOnceHandlerForEvent()
+		{
+			var wasSecondListenerCalled = false;
+			Action action = () => {};
+			var listener = new EventListener<DummyEvent>(evt => action());
+			action = () => {
+				testObj.RemoveListener<DummyEvent>(listener);
+			};
+			testObj.AddOnce<DummyEvent>(listener);
+			testObj.AddOnce<DummyEvent>(evt => wasSecondListenerCalled = true);
+
+			testObj.Dispatch<DummyEvent>();
+
+			Assert.IsTrue(wasSecondListenerCalled, "Second listener was not executed.");
+		}
 	}
 
 	public class DummyEvent : Event

--- a/BantamTest/EventBusTest.cs
+++ b/BantamTest/EventBusTest.cs
@@ -122,6 +122,23 @@ namespace Bantam.Test
 			testObj.Dispatch<DummyEvent>();
 			Assert.IsFalse(wasCalled);
 		}
+
+		[Test]
+		public void RemoveListenerSucceedsWhenCalledFromHandlerForEvent()
+		{
+			var wasSecondListenerCalled = false;
+			Action action = () => {};
+			var listener = new EventListener<DummyEvent>(evt => action());
+			action = () => {
+				testObj.RemoveListener<DummyEvent>(listener);
+			};
+			testObj.AddListener<DummyEvent>(listener);
+			testObj.AddListener<DummyEvent>(evt => wasSecondListenerCalled = true);
+
+			testObj.Dispatch<DummyEvent>();
+
+			Assert.IsTrue(wasSecondListenerCalled, "Second listener was not executed.");
+		}
 	}
 
 	public class DummyEvent : Event


### PR DESCRIPTION
Can now remove event handlers from from their own listeners. Previously this was problematic because you were modifying a list as it was being iterated over.