### PR TITLE
Adding OnFailure to Command chains

### DIFF
--- a/Bantam/CommandChain.cs
+++ b/Bantam/CommandChain.cs
@@ -9,6 +9,7 @@ namespace Bantam
 	public abstract class CommandChain
 	{
 		internal List<CommandAllocator> Commands = new List<CommandAllocator>();
+		internal CommandAllocator FailureCommand;
 	}
 
 	public class CommandChain<T> : CommandChain where T : class, Event
@@ -17,6 +18,11 @@ namespace Bantam
 		{
 			Commands.Add(new CommandAllocator<T, U>(initializer));
 			return this;
+		}
+
+		public void OnFailure<U>(CommandInitializer<U, T> initializer = null) where U : Command, new()
+		{
+			FailureCommand = new CommandAllocator<T, U>(initializer);
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ commandRelay.On<LoginEvent>()
 	.Do<ShowUsernameCommand>((cmd, evt) => cmd.loginEvent = evt)
 	.Do<ShowOptionsCommand>();
 
+//Handle a failed command chain
+commandRelay.On<UserDataRequestEvent>()
+	.Do<FailingCommand>()
+	.OnFailure<ResetUserDataCommand>();
+
 //Create a Model.
 modelRegistry.Create<UserDataModel>(mdl => mdl.username = "Jane Doe");
 ```


### PR DESCRIPTION
OnFailure can optionally be specified for Command chains so that a single Command will be executed if any of the Commands in the chain fail. The chain will complete once the OnFailure Command succeeds or fails.